### PR TITLE
CI: harden GHA configuration

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -7,6 +7,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
     - name: Grab Python
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
This adjusts the defaults per suggestions of zizmor to
reduce possible risks from giving GHA tasks more permissions
that required.
